### PR TITLE
Fix bug loading Hash DB incorrectly

### DIFF
--- a/Src/HashSearch.cpp
+++ b/Src/HashSearch.cpp
@@ -817,7 +817,7 @@ void CHashSearch::Search(string& sDbPre, int nSeqNum, vector<uchar>& vQSeqs, vec
 		m_ofTemp.open((m_sOutBase+".tmp"+lexical_cast<string>(j)).c_str());
 
 		// read db file and store info
-		MINDEX vDHash(m_unTotalIdx, VUINT()); // all k-mer of database
+		MINDEX vDHash(0, VUINT()); // all k-mer of database
 		vector<uint> vDLens;
 		vector<uchar> vDSeqs;
 		VNAMES vDNames;

--- a/Src/main.cpp
+++ b/Src/main.cpp
@@ -22,7 +22,7 @@ using namespace std;
 #define OPTION_BITS "i"
 #define OPTION_LOGE "s"
 #define	Program	"rapsearch"
-#define	Version "2.22"
+#define	Version "2.24"
 
 void printUsage(char *error);
 
@@ -241,24 +241,31 @@ void printUsage(char *error)
             "\t-" OPTION_QUERY        " string : query file or stdin (FASTA or FASTQ format)\n"
             "\t-" OPTION_SUBJECT      " string : database file (**base name only**, with full path)\n"
             "\t-" OPTION_OUTPUT       " string : output file name\n"
-            "\t-" OPTION_STDOUT       " int : stream one result through stdout [1: m8 result, 2: aln result, default: don't stream any result through stdout]\n"
-            "\t-" OPTION_THREADNUM         " int  : number of threads [default: %d]\n"
-            "\t-" OPTION_EVAL         " double  : threshold of log10(E-value)/E-value [default: %.1f/10.0]. It is the default threshold.\n"
-			"\t-" OPTION_LOGE       " char    : use log10(E-value)/Evalue as threshold [t/T: print hits using log10(E-value), f/F: print hits using E-value, default: t]\n"
-            "\t-" OPTION_BITS         " double  : threshold of bit score [default: %.1f]. It is the alternative option to report hits, instead of log-evalue.\n"
-            "\t-" OPTION_MINLEN         " int  : threshold of minimal alignment length [default: %d]\n"
-			"\t-" OPTION_MAXHIT       " int    : number of database sequences to show one-line descriptions [default: %d]. If it's -1, all results will be shown.\n"
-			"\t-" OPTION_MAXALN       " int    : number of database sequence to show alignments [default: %d]. If it's -1, all results will be shown.\n"
-			"\t-" OPTION_QUERYTYPE       " char    : type of query sequences [u/U:unknown, n/N:nucleotide, a/A:amino acid, q/Q:fastq, default: %s]\n"
-			"\t-" OPTION_PRINTEMPTY       " char    : output ALL/MATCHED query reads into the alignment file [t/T: output all query reads, f/F: output matched reads, default: %s]\n"
-			"\t-" OPTION_GAPEXT       " char    : perform gap extension to speed up [t/T: perform gap extension, f/F: do not perform gap extension, default: %s]\n"
-			"\t-" OPTION_ACCELERATE       " char    : fast mode (10~30 fold) [t/T: perform fast search, f/F: perform normal search, default: %s]\n"
-			"\t-" OPTION_HSSP       " char    : perform HSSP criteria instead of evalue criteria [t/T: perform HSSP criteria, f/F: perform evalue criteria, default: %s]\n"
-			"\t-" OPTION_XML       " char    : print hits in xml format [t/T: print hits in xml format, f/F: not print hits in xml format, default: %s]\n"
+            "\t-" OPTION_STDOUT       " int    : stream one result through stdout [1: m8 result, 2: aln result, default: don't stream any result through stdout]\n"
+            "\t-" OPTION_THREADNUM    " int    : number of threads [default: %d]\n"
+	    "\t-" OPTION_LOGE       " char   : report log10(E-value) or E-value for each hit [t/T: log10(E-value), the default; f/F: E-value]\n"
+            "\t-" OPTION_EVAL         " double : E-value threshold, given in the format of log10(E-value), or E-value (when -s is set to f) [default: %.1f/10.0]. \n"
+            "\t-" OPTION_BITS         " double : threshold of bit score [default: %.1f]. It is the alternative option to limit the hits to report.\n"
+            "\t-" OPTION_MINLEN         " int    : threshold of minimal alignment length [default: %d]\n"
+	    "\t-" OPTION_MAXHIT       " int    : number of database sequences to show one-line descriptions [default: %d]. If it's -1, all results will be shown.\n"
+	    "\t-" OPTION_MAXALN       " int    : number of database sequence to show alignments [default: %d]. If it's -1, all results will be shown.\n"
+	    "\t-" OPTION_QUERYTYPE       " char   : type of query sequences [u/U:unknown, n/N:nucleotide, a/A:amino acid, q/Q:fastq, default: %s]\n"
+	    "\t-" OPTION_PRINTEMPTY       " char   : output ALL/MATCHED query reads into the alignment file [t/T: output all query reads, f/F: output matched reads, default: %s]\n"
+	    "\t-" OPTION_GAPEXT       " char   : apply gap extension [t/T: yes, f/F: no, default: %s]\n"
+	    "\t-" OPTION_ACCELERATE       " char   : use fast mode (10~30 fold) [t/T: yes, f/F: no, default: %s]\n"
+	    "\t-" OPTION_HSSP       " char   : apply HSSP criterion instead of E-value criterion [t/T: HSSP, f/F: E-value criteria, default: %s]\n"
+     	    "\t-" OPTION_XML       " char   : print hits in xml format [t/T: yes, f/F: no, default: %s]\n"
             "-------------------------------------------------------------------------\n"
-            "example> %s -" OPTION_QUERY " query.fa -" OPTION_SUBJECT " nr -" OPTION_OUTPUT " output_file\n\n"
+            "example 1> %s -" OPTION_QUERY " query.fa -" OPTION_SUBJECT " nr -" OPTION_OUTPUT " output_file\n"
+            "example 2> %s -" OPTION_QUERY " query.fa -" OPTION_SUBJECT " nr -" OPTION_OUTPUT " output_file -" OPTION_BITS " 40 -" OPTION_MINLEN " 25\n"
+	    "   this setting only reports the hits with bit score >= 40 and alignment length >= 25\n"
+            "example 3> %s -" OPTION_QUERY " query.fa -" OPTION_SUBJECT " nr -" OPTION_OUTPUT " output_file -" OPTION_EVAL " -5\n"
+	    "   this setting only reports hits with log(E-value) <= -5 (i.e., E-value <= 1e-5)\n"
+            "example 4> %s -" OPTION_QUERY " query.fa -" OPTION_SUBJECT " nr -" OPTION_OUTPUT " output_file -" OPTION_EVAL " 1e-5 -" OPTION_LOGE " f\n"
+	    "   this setting only reports the hits with E-value <= 1e-5\n"
+	    "the difference between example 3 & 4 is that the former lists log(E-value) while the latter lists E-value for each hit in the output file\n"
             ,
-            Program, Version, 1, 1.0, 0.0, 0, 500, 100, "u", "f", "t", "f", "f", "f", Program
+            Program, Version, 1, 1.0, 0.0, 0, 500, 100, "u", "f", "t", "f", "f", "f", Program, Program, Program, Program
            );
     exit(-1);
 }

--- a/install
+++ b/install
@@ -12,20 +12,8 @@ make
 rm -f -r *.o
 
 cd $CDIR
-
-if test -d bin; then
-  read -n1 -p 'A local bin directory already exists, do you wish to overwrite? (Y/N)' booleanYorN
-  case $booleanYorN in
-   y|Y) echo "" ; rm -f -r bin ; mkdir bin ;;
-   n|N) echo "" ; echo "only replacing binary files in local bin dir" ;;
-   *) echo "" ; echo "invalid Input "; exit 1 ;;
-  esac
-else 
-  mkdir bin
-fi
-
-
-
+rm -f -r bin
+mkdir bin
 
 mv $TMPDIR/rapsearch bin/rapsearch
 mv $TMPDIR/prerapsearch bin/

--- a/readme
+++ b/readme
@@ -1,6 +1,6 @@
 Program Name: RAPSearch (rapsearch)
-Version: 2.22 -- *** a version that supports multiple threads **
-Released: Oct 27, 2014 (RAPSearch2.0 was released May 26, 2011)
+Version: 2.24 -- *** a version that supports multiple threads **
+Released: Sep 27, 2016 (RAPSearch2.0 was released May 26, 2011)
 Developers: Yongan Zhao <yongzhao@indiana.edu> Yuzhen Ye <yye@indiana.edu>, and Haixu Tang <hatang@indiana.edu>
 Affiliation: School of Informatics and Computing, Indiana University, Bloomington
 
@@ -8,14 +8,6 @@ The development of rapsearch was supported by NIH grant 1R01HG004908 to YY
 
 rapsearch is free software under the terms of the GNU General Public License as published by 
 the Free Software Foundation.
-
->> If you are switching from RAPSearch1.0 to RAPSearch2.0
-   RAPSearch2 runs faster than RAPSearch1, uses less memory,
-   and best of all, RAPSearch2 supports mult-threads!!
-   You can define the number of threads that you want to use by setting -z parameter (see below)
-
-   NOTE: if you switch from RAPSearch1.0 to RAPSearch2.0, 
-	you need to re-run prerapsearch to prepare new database files!!
 
 >> Before you start
    RAPSearch means Reduced Alphabet based Protein similarity Search 
@@ -25,12 +17,8 @@ the Free Software Foundation.
 
    RAPSearch2 on the web: 
    http://rapsearch2.sourceforge.net/
-   http://omics.informatics.indiana.edu/mg/RAPSearch2
-  (please check the project home page for updates and newer version of the rapsearch)
-   (RAPSearch1 on the web: http://omics.informatics.indiana.edu/mg/RAPSearch)
 
 >> Installation
-
    simply call: ./install
 
    The executable files "rapsearch" and "prerapsearch"
@@ -61,10 +49,13 @@ the Free Software Foundation.
 
    Usage: type rapsearch for usages
 
+   Following examples are used to demonstrate the use of different options
+   See Examples 5 & 6 for usage of -e and -s options 
+
    Example 1: rapsearch -q 4440037.3.dna.fa -d nogCOGdomN95_db -o 4440037.3.dna-vs-nogCOGdomN95 -z 4
    Input:  4440037.3.dna.fa #query file, note if it is a file of short nucleotide sequences, 
     	   nogCOGdomN95_db     #the base name of the similarity search database 
-   (here -z is set to 4, so that four threads be used) 
+   (here -z is set to 4, so that four threads will be used) 
 
    Output: 4440037.3.dna-vs-nogCOGdomN95.m8  #the similarty search result, 
                                              #one hit in one line, like -m 8 output from blast
@@ -74,15 +65,20 @@ the Free Software Foundation.
 					     #maximum 100 alignments per query
 
    Example 2: cat 4440037.4440037.3.dna | rapsearch -q stdin -d nogCOGdomN95_db -o 4440037.3.dna-vs-nogCOGdomN95 -z 4
-   Input: stdin of system. 
-   It's easy and convinient to incorporate RAPSearch into the pipeline
+   Input: stdin of system. (-q stdin) 
 
    Example 3: rapsearch -q 4440037.3.dna.fa -d nogCOGdomN95_db -o 4440037.3.dna-vs-nogCOGdomN95 -z 4 -b 0
    Output: Only output m8 file.
 
    Example 4: rapsearch -q 4440037.3.dna.fa -d nogCOGdomN95_db -z 4 -u 1
    Output: Only generate m8 file and output it to stdout of system.
-   It's easy and convinient to incorporate RAPSearch into the pipeline
+
+   Example 5: rapsearch -q 4440037.3.dna.fa -d nogCOGdomN95_db -o 4440037.3.dna-vs-nogCOGdomN95 -z 4 -e -5
+   In this example, "-e -5" (note NOT -e 1e-5) is used to limit only output hits with E-values <= 1e-5, i.e., 10^(-5)
+
+   Example 6: rapsearch -q 4440037.3.dna.fa -d nogCOGdomN95_db -o 4440037.3.dna-vs-nogCOGdomN95 -z 4 -e 1e-5 -s f
+   In this example, "-s f" tells the program to output similarity hits with E-values instead of log(E-values) to 
+   the output file, and "-e 1e-5" instead of "-e -5" tells the program to only output hits with E-values <= 1e-5
 
    Notes:  
  	  a) By default, rapsearch program uses only one thread; you may use -z to change the threads


### PR DESCRIPTION
By initializing the vector with size 1M, boost serialization appends the
db hash file onto the vector making it 2M / twice as long.

Hash queries would return no-hit for every seed because of the empty 1M
prefix